### PR TITLE
Fix some test fails

### DIFF
--- a/match.dylan
+++ b/match.dylan
@@ -361,8 +361,9 @@ define method descend-re
     (re :: <parsed-set>, target :: <substring>, case-sensitive? :: <boolean>,
      start-index :: <integer>, marks :: <mutable-sequence>,
      backtrack-past-me :: <non-local-exit>, up-list :: <list>) => ();
+  let tester = if (case-sensitive?) \== else char-equal-ic? end;
   if (start-index < target.end-index
-        & member?(target.entire-string[start-index], re.char-set))
+        & member?(target.entire-string[start-index], re.char-set, test: tester))
     head(up-list)(start-index + 1, backtrack-past-me, tail(up-list));
   else
     backtrack-past-me();

--- a/parse.dylan
+++ b/parse.dylan
@@ -522,6 +522,10 @@ define inline function parse-simple-group
                 let re = parse-regex(str, info);
                 if (lookahead(str) == ')')
                   consume(str)
+		else
+		  parse-error(str.parse-string,
+			      "Unterminated group at index %s.",
+			      str.parse-index);
                 end;
                 re
               end;

--- a/tests/api.dylan
+++ b/tests/api.dylan
@@ -70,8 +70,7 @@ define regular-expressions function-test regex-position ()
   check-pos("pos test #r", "a+", "AAaAA", #[0, 5], case-sensitive: #f);
   check-pos("pos test #s", "a+", "AAaAA", #[2, 3]);
   check-pos("pos test #t", "[a-f]+", "SdFbIeNvI", #[1, 2]);
-  // This one is failing due to bug 7371
-  check-pos("pos test #u", "[a-f]+", "SdFbIeNvI", #[1, 4], case-sensitve: #f);
+  check-pos("pos test #u", "[a-f]+", "SdFbIeNvI", #[1, 4], case-sensitive: #f);
   check-pos("pos test #v", "[\\s\\]]+", "blah[   \t]", #[5, 10]);
 
   // test escaped characters

--- a/tests/api.dylan
+++ b/tests/api.dylan
@@ -109,12 +109,12 @@ end function-test regex-group-count;
 define regular-expressions function-test regex-search ()
   // Test case-sensitive parameter
   // See bug 7371
+  check-false("regex-search(..., case-sensitive: #t) works on character sets",
+             regex-search(compile-regex("[a-z]"), "A", case-sensitive: #t));
   check-true("regex-search(..., case-sensitive: #f) works for character sets",
              regex-search(compile-regex("[a-z]"), "A", case-sensitive: #f));
-  check-true("regex-search(..., case-sensitive: #t) works on character sets",
-             regex-search(compile-regex("[a-z]"), "A", case-sensitive: #f));
   check-false("case-sensitive: #t works for regular strings",
-              regex-search(compile-regex("abc"), "aBc", case-sensitive: #t));
+             regex-search(compile-regex("abc"), "aBc", case-sensitive: #t));
   check-true("case-sensitive: #f works for regular strings",
              regex-search(compile-regex("abc"), "ABC", case-sensitive: #f));
 end function-test regex-search;


### PR DESCRIPTION
These commits fix some of the test failures in this library.

Not fixed: the protocol errors, or the 'pcre-test'
Also I am not sure the case-insensitive code is correct for character sets (e.g. [a-z]) - if you ask for a case insensitive match on a set initialized as case sensitive it will fall back to a less efficient method.
