### PR TITLE
Update to match simplified testworks specs

### DIFF
--- a/tests/api.dylan
+++ b/tests/api.dylan
@@ -1,6 +1,6 @@
 Module: regular-expressions-test-suite
 
-define regular-expressions function-test regex-position ()
+define test test-regex-position ()
   check-no-errors("regex-position with a regex regex",
                   regex-position(compile-regex("pattern"), "pattern"));
   local method check-pos
@@ -79,9 +79,9 @@ define regular-expressions function-test regex-position ()
   check-condition("pos test #y",
                   <invalid-regex>,
                   compile-regex("((a*)|(b*))*c"));
-end function-test regex-position;
+end test;
 
-define regular-expressions function-test regex-replace ()
+define test test-regex-replace ()
   let big-string = "The rain in spain and some other text";
   check-no-errors("regex-replace with regex pattern",
                   regex-replace(big-string,
@@ -99,13 +99,13 @@ define regular-expressions function-test regex-replace ()
   check-equal("regex-replace #4",
               regex-replace(big-string, compile-regex("in"), "out", start: 8, end: 15),
               "The rain out spain and some other text");
-end function-test regex-replace;
+end test;
 
-define regular-expressions function-test regex-group-count ()
+define test test-regex-group-count ()
   //---*** Fill this in...
-end function-test regex-group-count;
+end test;
 
-define regular-expressions function-test regex-search ()
+define test test-regex-search ()
   // Test case-sensitive parameter
   check-false("regex-search(..., case-sensitive: #t) works on character sets",
               regex-search(compile-regex("[a-z]"), "A", case-sensitive: #t));
@@ -115,9 +115,9 @@ define regular-expressions function-test regex-search ()
               regex-search(compile-regex("abc"), "aBc", case-sensitive: #t));
   check-true("case-sensitive: #f works for regular strings",
              regex-search(compile-regex("abc"), "ABC", case-sensitive: #f));
-end function-test regex-search;
+end test;
 
-define regular-expressions function-test compile-regex ()
+define test test-compile-regex ()
   // Test caching
   check-true("use-cache: #t uses the cache",
              compile-regex("abc") == compile-regex("abc", use-cache: #t));
@@ -128,84 +128,84 @@ define regular-expressions function-test compile-regex ()
   // Test verbose parameter
   // Test multi-line parameter
   // Test dot-matches-all parameter
-end function-test compile-regex;
+end test;
 
-define regular-expressions class-test <regex> ()
+define test test-<regex> ()
   //---*** Fill this in...
-end class-test <regex>;
+end test;
 
 define sideways method make-test-instance
     (class == <regex>) => (regex :: <regex>)
   compile-regex("foo")
 end;
 
-define regular-expressions class-test <regex-error> ()
+define test test-<regex-error> ()
   //---*** Fill this in...
-end class-test <regex-error>;
+end test;
 
-define regular-expressions class-test <invalid-regex> ()
+define test test-<invalid-regex> ()
   //---*** Fill this in...
-end class-test <invalid-regex>;
+end test;
 
 define sideways method make-test-instance
     (class == <invalid-regex>) => (error :: <invalid-regex>)
   make(<invalid-regex>, pattern: "[unterminated")
 end;
 
-define regular-expressions function-test regex-error-pattern ()
+define test test-regex-error-pattern ()
   //---*** Fill this in...
-end function-test regex-error-pattern;
+end test;
 
-define regular-expressions function-test regex-search-strings ()
+define test test-regex-search-strings ()
   //---*** Fill this in...
-end function-test regex-search-strings;
+end test;
 
-define regular-expressions class-test <invalid-match-group> ()
+define test test-<invalid-match-group> ()
   //---*** Fill this in...
-end class-test <invalid-match-group>;
+end test;
 
-define regular-expressions function-test group-text ()
+define test test-group-text ()
   //---*** Fill this in...
-end function-test group-text;
+end test;
 
-define regular-expressions function-test group-end ()
+define test test-group-end ()
   //---*** Fill this in...
-end function-test group-end;
+end test;
 
-define regular-expressions function-test group-start ()
+define test test-group-start ()
   //---*** Fill this in...
-end function-test group-start;
+end test;
 
-define regular-expressions function-test groups-by-name ()
+define test test-groups-by-name ()
   //---*** Fill this in...
-end function-test groups-by-name;
+end test;
 
-define regular-expressions function-test groups-by-position ()
+define test test-groups-by-position ()
   //---*** Fill this in...
-end function-test groups-by-position;
+end test;
 
-define regular-expressions function-test match-group ()
+define test test-match-group ()
   //---*** Fill this in...
-end function-test match-group;
+end test;
 
-define regular-expressions class-test <match-group> ()
+define test test-<match-group> ()
   //---*** Fill this in...
-end class-test <match-group>;
+end test;
 
 define sideways method make-test-instance
     (class == <match-group>) => (group :: <match-group>)
   make(<match-group>, text: "foo", start: 0, end: 3)
 end;
 
-define regular-expressions class-test <regex-match> ()
+define test test-<regex-match> ()
   //---*** Fill this in...
-end class-test <regex-match>;
+end test;
 
 define sideways method make-test-instance
     (class == <regex-match>) => (match :: <regex-match>)
   make(<regex-match>, regular-expression: compile-regex("foo"))
 end;
 
-define regular-expressions function-test regex-pattern ()
+define test test-regex-pattern ()
   //---*** Fill this in...
-end function-test regex-pattern;
+end test;

--- a/tests/library.dylan
+++ b/tests/library.dylan
@@ -10,12 +10,9 @@ define library regular-expressions-test-suite
               operating-system };
   use strings;
   use testworks;
-  use testworks-specs;
   use regular-expressions,
     import: { regex-implementation };
-
-  export regular-expressions-test-suite;
-end library regular-expressions-test-suite;
+end library;
 
 define module regular-expressions-test-suite
   use common-dylan;
@@ -30,12 +27,9 @@ define module regular-expressions-test-suite
   use operating-system,
     import: { environment-variable };
   use testworks;
-  use testworks-specs;
   use streams;
   use strings,
     import: { strip-left };
-
-  export regular-expressions-test-suite;
-end module regular-expressions-test-suite;
+end module;
 
 

--- a/tests/regular-expressions-test-suite.dylan
+++ b/tests/regular-expressions-test-suite.dylan
@@ -123,47 +123,17 @@ define test invalid-regex-test ()
   end;
 end test invalid-regex-test;
 
-define test pcre-testoutput1 ()
-  run-pcre-checks(make-pcre-locator("pcre-testoutput1.txt"));
-end;
+// TODO(cgay): Commented out until https://github.com/dylan-lang/testworks/issues/98
+// is fixed.
 
-define suite pcre-test-suite ()
-  test pcre-testoutput1;
-end;
+// define test pcre-testoutput1 ()
+//   run-pcre-checks(make-pcre-locator("pcre-testoutput1.txt"));
+// end;
 
-ignore(pcre-test-suite);
+// define suite pcre-test-suite ()
+//   test pcre-testoutput1;
+// end;
 
-define test regressions-test ()
-  run-pcre-checks(make-pcre-locator("regression-tests.txt"));
-end;
-
-ignore(regressions-test);
-
-define suite regular-expressions-test-suite ()
-  test split-test;
-  test atom-test;
-  test ad-hoc-regex-test;
-  test invalid-regex-test;
-
-  // I've changed lots of things that make the gdref documentation
-  // out-of-date, but it still might be useful to look it over for
-  // test ideas.
-  //test gdref-documentation-test;
-
-  suite regular-expressions-api-test-suite;
-
-  // TODO(cgay): Commented out until https://github.com/dylan-lang/testworks/issues/98
-  // is fixed.
-  //suite pcre-test-suite;
-  //test regressions-test;
-end;
-
-define method main
-    () => ()
-  let filename = locator-name(as(<file-locator>, application-name()));
-  if (split(filename, ".")[0] = "regular-expressions-test-suite")
-    run-test-application(regular-expressions-test-suite);
-  end;
-end;
-
-main();
+// define test regressions-test ()
+//   run-pcre-checks(make-pcre-locator("regression-tests.txt"));
+// end;

--- a/tests/regular-expressions-test-suite.lid
+++ b/tests/regular-expressions-test-suite.lid
@@ -2,5 +2,4 @@ library: regular-expressions-test-suite
 files: library
        api
        specification
-       pcre
        regular-expressions-test-suite

--- a/tests/specification.dylan
+++ b/tests/specification.dylan
@@ -1,56 +1,52 @@
 Module: regular-expressions-test-suite
 
-define module-spec regular-expressions ()
+define interface-specification-suite regular-expressions-specification-suite ()
   sealed instantiable class <regex> (<mark>);
   sealed instantiable class <regex-error> (<format-string-condition>, <error>);
   sealed instantiable class <invalid-regex> (<regex-error>);
-  sealed generic-function regex-error-pattern
+  sealed generic function regex-error-pattern
       (<invalid-regex>) => (<string>);
   sealed instantiable class <invalid-match-group> (<regex-error>);
   sealed instantiable class <match-group> (<object>);
   sealed instantiable class <regex-match> (<object>);
 
   // Compiling and accessing regex info
-  sealed generic-function compile-regex
+  sealed generic function compile-regex
       (<string>, #"key", #"case-sensitive", #"dot-matches-all", #"verbose", #"multi-line")
       => (<regex>);
-  sealed generic-function regex-pattern (<regex>) => (<string>);
-  sealed generic-function regex-group-count
+  sealed generic function regex-pattern (<regex>) => (<string>);
+  sealed generic function regex-group-count
       (<regex>) => (<integer>);
 
   // Search and replace
-  sealed generic-function regex-position
+  sealed generic function regex-position
       (<regex>, <string>, #"key", #"start", #"end", #"case-sensitive")
       => (false-or(<integer>), #"rest");
-  sealed generic-function regex-replace
+  sealed generic function regex-replace
       (<string>, <regex>, <string>, #"key", #"start", #"end", #"case-sensitive", #"count")
       => (<string>);
-  sealed generic-function regex-search
+  sealed generic function regex-search
       (<regex>, <string>, #"key", #"anchored", #"start", #"end")
       => (false-or(<regex-match>));
-  sealed generic-function regex-search-strings
+  sealed generic function regex-search-strings
       (<regex>, <string>, #"key", #"anchored", #"start", #"end")
       => (false-or(<regex-match>));
 
   // Accessing match groups
-  sealed generic-function groups-by-position
+  sealed generic function groups-by-position
       (<regex-match>) => (<sequence>);
-  sealed generic-function groups-by-name
+  sealed generic function groups-by-name
       (<regex-match>) => (<string-table>);
-  sealed generic-function match-group
+  sealed generic function match-group
       (<regex-match>, <object>) => (false-or(<string>), false-or(<integer>), false-or(<integer>));
 
   // Accessing individual group data
-  sealed generic-function group-text
+  sealed generic function group-text
       (<match-group>) => (false-or(<string>));
-  sealed generic-function group-end
+  sealed generic function group-end
       (<match-group>) => (false-or(<integer>));
-  sealed generic-function group-start
+  sealed generic function group-start
       (<match-group>) => (false-or(<integer>));
-end module-spec regular-expressions;
+end regular-expressions-specification-suite;
 
-
-define library-spec regular-expressions-api ()
-  module regular-expressions;
-end;
-
+ignore(regular-expressions-specification-suite);


### PR DESCRIPTION
Also removed exports and conditional "main" function. (Use testworks-run instead.)